### PR TITLE
remove warning during make && sudo make install

### DIFF
--- a/Install/src/RADProc.cc
+++ b/Install/src/RADProc.cc
@@ -627,7 +627,7 @@ for (int i = 0; i < (int)keys.size(); i++) {
     	consensus[keys[i]]=con;    
     
    }
-
+return 0;
 }
 
 
@@ -2043,7 +2043,7 @@ vector<int> mkeys;
 
 write_catalog(ctags, path);
 ctags.clear();
-
+return 0;
 }
 
 


### PR DESCRIPTION
To remove those warnings during ` make && sudo make install`:
```
RADProc.cc:631:1: warning: no return statement in function returning non-void [-Wreturn-type]
  631 | }
      | ^
RADProc.cc: In function 'int mergeStacks(std::map<int, Tag*>&, std::vector<std::__cxx11::basic_string<char> >&, int, int, std::ofstream&)':
RADProc.cc:2047:1: warning: no return statement in function returning non-void -Wreturn-type]
 2047 | }
      | ^
```

I added `return 0;` to the required lines...